### PR TITLE
fix: only run comment on pull request after tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,27 +20,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.5.13"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-
       - name: Install the project
         run: uv sync --extra train --extra deployment
-
       - name: Run tests
         run: uv run coverage run --source=src/ -m pytest
-
       - name: Generate coverage report
         run: |
           echo '## Code Coverage Report' >> cov.md
           uv run coverage report -m --format="markdown" >> cov.md
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: cov.md
 
+  comment:
+    needs: test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download coverage report
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report
       - name: Find Comment
-        if: github.event.pull_request
         uses: peter-evans/find-comment@v3
         continue-on-error: true
         id: fc
@@ -48,8 +58,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'Coverage'
-
-      - name: Create comment
+      - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id || '' }}


### PR DESCRIPTION
We don't want to comment on coverage more than once, and we want to do so after the coverage report has been generated. By separating test and comment, we achieve this.